### PR TITLE
Allow Custom marshallers with ChainedConverterConfiguration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,9 @@ dependencies {
     testCompile("org.spockframework:spock-core:${spockVersion}") {
         exclude module:'groovy-all'
     }
+
+    testCompile "org.grails:grails-datastore-rest-client:6.1.10.RELEASE"
+    testCompile "org.grails:grails-web-testing-support:1.1.4"
 }
 
 // enable if you wish to package this plugin as a standalone application

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 grailsVersion=3.3.0
-spockVersion=1.0-groovy-2.4
+spockVersion=1.1-groovy-2.4

--- a/src/main/groovy/grails/converters/JSON.java
+++ b/src/main/groovy/grails/converters/JSON.java
@@ -26,6 +26,7 @@ import org.grails.web.converters.AbstractConverter;
 import org.grails.web.converters.Converter;
 import org.grails.web.converters.ConverterUtil;
 import org.grails.web.converters.IncludeExcludeConverter;
+import org.grails.web.converters.configuration.ChainedConverterConfiguration;
 import org.grails.web.converters.configuration.ConverterConfiguration;
 import org.grails.web.converters.configuration.ConvertersConfigurationHolder;
 import org.grails.web.converters.configuration.DefaultConverterConfiguration;
@@ -410,11 +411,23 @@ public class JSON extends AbstractConverter<JSONWriter> implements IncludeExclud
         if (cfg == null) {
             throw new ConverterException("Default Configuration not found for class " + JSON.class.getName());
         }
-        if (!(cfg instanceof DefaultConverterConfiguration<?>)) {
-            cfg = new DefaultConverterConfiguration<JSON>(cfg);
-            ConvertersConfigurationHolder.setDefaultConfiguration(JSON.class, cfg);
+        if (cfg instanceof ChainedConverterConfiguration<?>) {
+            // This has been called post-plugin initialization, so add it to
+            // the collection
+            cfg.getOrderedObjectMarshallers().add(om);
+
+            // Re-instantiate the chained config to rebuild the chain
+            ChainedConverterConfiguration<JSON> newCfg = new ChainedConverterConfiguration<>(cfg);
+            ConvertersConfigurationHolder.setDefaultConfiguration(JSON.class, newCfg);
+
+        } else {
+
+            if (!(cfg instanceof DefaultConverterConfiguration<?>)) {
+                cfg = new DefaultConverterConfiguration<JSON>(cfg);
+                ConvertersConfigurationHolder.setDefaultConfiguration(JSON.class, cfg);
+            }
+            ((DefaultConverterConfiguration<JSON>) cfg).registerObjectMarshaller(om);
         }
-        ((DefaultConverterConfiguration<JSON>) cfg).registerObjectMarshaller(om);
     }
 
     public static void registerObjectMarshaller(ObjectMarshaller<JSON> om, int priority) throws ConverterException {

--- a/src/main/groovy/grails/converters/XML.java
+++ b/src/main/groovy/grails/converters/XML.java
@@ -33,6 +33,7 @@ import org.grails.web.converters.AbstractConverter;
 import org.grails.web.converters.Converter;
 import org.grails.web.converters.ConverterUtil;
 import org.grails.web.converters.IncludeExcludeConverter;
+import org.grails.web.converters.configuration.ChainedConverterConfiguration;
 import org.grails.web.converters.configuration.ConverterConfiguration;
 import org.grails.web.converters.configuration.ConvertersConfigurationHolder;
 import org.grails.web.converters.configuration.DefaultConverterConfiguration;
@@ -411,11 +412,22 @@ public class XML extends AbstractConverter<XMLStreamWriter> implements IncludeEx
         if (cfg == null) {
             throw new ConverterException("Default Configuration not found for class " + XML.class.getName());
         }
-        if (!(cfg instanceof DefaultConverterConfiguration<?>)) {
-            cfg = new DefaultConverterConfiguration<XML>(cfg);
-            ConvertersConfigurationHolder.setDefaultConfiguration(XML.class, cfg);
+        if (cfg instanceof ChainedConverterConfiguration<?>) {
+            // This has been called post-plugin initialization, so add it to
+            // the collection
+            cfg.getOrderedObjectMarshallers().add(om);
+
+            // Re-instantiate the chained config to rebuild the chain
+            ChainedConverterConfiguration<XML> newCfg = new ChainedConverterConfiguration<>(cfg);
+            ConvertersConfigurationHolder.setDefaultConfiguration(XML.class, newCfg);
+
+        } else {
+            if (!(cfg instanceof DefaultConverterConfiguration<?>)) {
+                cfg = new DefaultConverterConfiguration<XML>(cfg);
+                ConvertersConfigurationHolder.setDefaultConfiguration(XML.class, cfg);
+            }
+            ((DefaultConverterConfiguration<XML>) cfg).registerObjectMarshaller(om);
         }
-        ((DefaultConverterConfiguration<XML>) cfg).registerObjectMarshaller(om);
     }
 
     public static void registerObjectMarshaller(ObjectMarshaller<XML> om, int priority) throws ConverterException {

--- a/src/test/groovy/org/grails/plugins/converters/api/RuntimeRegisterMarshallerSpec.groovy
+++ b/src/test/groovy/org/grails/plugins/converters/api/RuntimeRegisterMarshallerSpec.groovy
@@ -1,0 +1,50 @@
+package org.grails.plugins.converters.api
+
+import grails.converters.JSON
+import grails.plugins.rest.client.RestBuilder
+import grails.testing.spring.AutowiredTest
+import grails.validation.ValidationErrors
+import org.grails.web.converters.exceptions.ConverterException
+import spock.lang.Issue
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class RuntimeRegisterMarshallerSpec extends Specification implements AutowiredTest {
+//class RuntimeRegisterMarshallerSpec extends Specification implements GrailsUnitTest {
+
+    // NOTE: this must implement Autowired test for the happy-path to work.
+
+    Set<String> getIncludePlugins() {
+        ["converters"].toSet()
+    }
+
+    @Issue('https://github.com/grails-plugins/grails-plugin-converters/issues/10')
+    @Unroll
+    void 'init rest builder #initRestBuilder does not poison JSON rendering'() {
+        given: 'an errors object to render'
+        def errors = new ValidationErrors('foo', 'bar')
+
+        and: 'a new object marshaller is registered, does not matter the class'
+        // This call switches the configuration from the ChainedConverterConfiguration to a DefaultConverterConfiguration.
+        // It would appear that they are incompatible.
+        JSON.registerObjectMarshaller(Date, {
+            [message: 'this is a date']
+        })
+
+        if (initRestBuilder) {
+            def rest = new RestBuilder()
+            // Workaround mentioned in
+            // https://github.com/grails/grails-data-mapping/issues/864
+//            def rest = new RestBuilder(registerConverters: false)
+        }
+
+        when: 'the object is rendered'
+        (errors as JSON).toString()
+
+        then: 'no exception is thrown'
+        notThrown(ConverterException)
+
+        where:
+        initRestBuilder << [false, true]
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/grails-plugins/grails-plugin-converters/issues/10

* Add spec for registering marshallers post-configuration
* Update spock dependency to 1.1
* Add grails testing support to include plugins in unit tests
* Ensure custom marshaller registration does not blow away existing chained converter configuration