### PR TITLE
fix(core): A runtime `NullPointerException` when `extractValues` is called with `null` `property`

### DIFF
--- a/src/main/groovy/org/grails/web/converters/marshaller/json/DomainClassMarshaller.java
+++ b/src/main/groovy/org/grails/web/converters/marshaller/json/DomainClassMarshaller.java
@@ -283,6 +283,9 @@ public class DomainClassMarshaller extends IncludeExcludePropertyMarshaller<JSON
     }
 
     protected Object extractValue(Object domainObject, PersistentProperty property) {
+        if(property == null) {
+            return null;
+        }
         if(domainObject instanceof GroovyObject) {
             return ((GroovyObject)domainObject).getProperty(property.getName());
         }


### PR DESCRIPTION
Fix a runtime `NullPointerException` when `extractValues` is called with `null` `property`. 

# How to Reproduce 
(this is a simplified version of the code, I hope it works):

Define a Gorm model like this
```
class Category() {
  int id 
  String name
  static mappedBy = [children: "children"]

   List <Category> children {
     def c = CategoryRelation.createCriteria()
     def ids = c.list( eq (b, id) )
     return this.createCriteria().list(in ('id', ids)
  }

}

class CategoryRelation() {
a Category,
b Category
  static mapping = {
    id composite: [a, b]
  }
}
```

```
def parent = new Category(name: "parent").save()
def child = new Category(name: "Child").save()
def relation = new CategoryRelation(a: parent, b: child).save()
```
```
>>> parent as JSON
```
In this case, it will call `DomainClassMarshaller.asShortObject(_, _, referencedIdProperty *<= null*, CategoryRelation)` 